### PR TITLE
add script to generate a home repo from a template

### DIFF
--- a/create_repo_from_template.sh
+++ b/create_repo_from_template.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+curl \
+  -i -u "${USERNAME}:${TOKEN}" \
+  -X POST \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/lab-antwerp-1/home/generate" \
+  -d '{"owner": "'"$ORG"'", "name":"'"$REPO_NAME"'"}'


### PR DESCRIPTION
we might want to put the canonical source of truth somewhere other than lamb-antwerp-1/home, but this works for now, so we might as well test it out and iterate.